### PR TITLE
Fix a bug in Pipeline derivation. It was not always possible to redef…

### DIFF
--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -253,7 +253,7 @@ class Pipeline(Process):
         self.get(name)
 
         # If we insert a user trait, create the associated plug
-        if self.is_user_trait(trait):
+        if getattr(self, 'pipeline_node', False) and self.is_user_trait(trait):
             output = bool(trait.output)
             optional = bool(trait.optional)
             plug = Plug(output=output, optional=optional)


### PR DESCRIPTION
…ine __init__ in a class derived from Pipeline because Process.__init__ calls Pipeline.add_trait (if there are class trait defined) that expect self.pipeline_node to be created.