### PR TITLE
generate temporary files when needed in sequential execution

### DIFF
--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -1190,10 +1190,9 @@ class Pipeline(Process):
                 continue
             trait = node.get_trait(plug_name)
             if not trait.output \
-                    or (not isinstance(trait.trait_type,
-                                        traits.File) \
+                    or (not isinstance(trait.trait_type, traits.File)
                         and not isinstance(trait.trait_type,
-                                            traits.Directory)) \
+                                           traits.Directory)) \
                     or len(plug.links_to) == 0:
                 continue
             # check that it is really temporary: not exported

--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -31,7 +31,7 @@ except ImportError:
         List, Tuple, Instance, Any, Event, CTrait, Directory, Trait)
 
 # Capsul import
-from capsul.process import Process
+from capsul.process import Process, NipypeProcess
 from capsul.process import get_process_instance
 from topological_sort import GraphNode
 from topological_sort import Graph
@@ -1183,6 +1183,12 @@ class Pipeline(Process):
             list of temporary files for the pipeline execution. The list will
             be modified (completed).
         """
+        process = getattr(node, 'process', None)
+        if process is not None and isinstance(process, NipypeProcess):
+            #nipype processes do not use temporaries, they produce output
+            # file names
+            return
+
         for plug_name, plug in node.plugs.iteritems():
             value = node.get_plug_value(plug_name)
             if not plug.activated or not plug.enabled \

--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -1164,6 +1164,82 @@ class Pipeline(Process):
 
         return workflow_list
 
+    def _check_temporary_files_for_node(self, node, temp_files):
+        """ Check temporary outputs and allocate files for them.
+
+        Temporary files or directories will be appended to the temp_files list,
+        and the node parameters will be set to temp file names.
+
+        This internal function is called by the sequential execution,
+        _run_process() (also used through __call__()).
+        The pipeline state will be restored at the end of execution using
+        _free_temporary_files().
+
+        Parameters
+        ----------
+        node: Node
+            node to check temporary outputs on
+        temp_files: list
+            list of temporary files for the pipeline execution. The list will
+            be modified (completed).
+        """
+        for plug_name, plug in node.plugs.iteritems():
+            value = node.get_plug_value(plug_name)
+            if not plug.activated or not plug.enabled \
+                    or value not in (traits.Undefined, ''):
+                continue
+            trait = node.get_trait(plug_name)
+            if not trait.output \
+                    or (not isinstance(trait.trait_type,
+                                        traits.File) \
+                        and not isinstance(trait.trait_type,
+                                            traits.Directory)) \
+                    or len(plug.links_to) == 0:
+                continue
+            # check that it is really temporary: not exported
+            # to the main pipeline
+            if self.pipeline_node in [link[2]
+                                      for link in plug.links_to]:
+                # it is visible out of the pipeline: not temporary
+                continue
+            # if we get here, we are a temporary.
+            if trait.trait_type is traits.Directory:
+                tmpdir = tempfile.mkdtemp(suffix='capsul_run')
+                temp_files.append((node, plug_name, tmpdir, value))
+                node.set_plug_value(plug_name, tmpdir)
+            else:
+                tmpfile = tempfile.mkstemp(suffix='capsul')
+                node.set_plug_value(plug_name, tmpfile[1])
+                os.close(tmpfile[0])
+                temp_files.append((node, plug_name, tmpfile[1], value))
+
+    def _free_temporary_files(self, temp_files):
+        """ Delete and reset temp files after the pipeline execution.
+
+        This internal function is called at the end of _run_process()
+        (sequential execution)
+        """
+        #
+        for node, plug_name, tmpfile, value in temp_files:
+            node.set_plug_value(plug_name, value)
+            if os.path.isdir(tmpfile):
+                try:
+                    shutil.rmtree(tmpfile)
+                except:
+                    pass
+            else:
+                try:
+                    os.unlink(tmpfile)
+                except:
+                    pass
+            # handle additional files (.hdr, .minf...)
+            # TODO
+            if os.path.exists(tmpfile + '.minf'):
+                try:
+                    os.unlink(tmpfile + '.minf')
+                except:
+                    pass
+
     def _run_process(self):
         """ Execution of the pipeline.
 
@@ -1185,35 +1261,7 @@ class Pipeline(Process):
             for node in nodes_list:
 
                 # check temporary outputs and allocate files
-                for plug_name, plug in node.plugs.iteritems():
-                    value = node.get_plug_value(plug_name)
-                    if not plug.activated or not plug.enabled \
-                            or value not in (traits.Undefined, ''):
-                        continue
-                    trait = node.get_trait(plug_name)
-                    if not trait.output \
-                            or (not isinstance(trait.trait_type,
-                                               traits.File) \
-                                and not isinstance(trait.trait_type,
-                                                   traits.Directory)) \
-                            or len(plug.links_to) == 0:
-                        continue
-                    # check that it is really temporary: not exported
-                    # to the main pipeline
-                    if self.pipeline_node in [link[2]
-                                              for link in plug.links_to]:
-                        # it is visible out of the pipeline: not temporary
-                        continue
-                    # if we get here, we are a temporary.
-                    if trait.trait_type is traits.Directory:
-                        tmpdir = tempfile.mkdtemp(suffix='capsul_run')
-                        temp_files.append((node, plug_name, tmpdir, value))
-                        node.set_plug_value(plug_name, tmpdir)
-                    else:
-                        tmpfile = tempfile.mkstemp(suffix='capsul')
-                        node.set_plug_value(plug_name, tmpfile[1])
-                        os.close(tmpfile[0])
-                        temp_files.append((node, plug_name, tmpfile[1], value))
+                self._check_temporary_files_for_node(node, temp_files)
 
                 # Execute the process contained in the node
                 node_ret = node.process()
@@ -1221,24 +1269,7 @@ class Pipeline(Process):
 
         finally:
             # delete and reset temp files
-            for node, plug_name, tmpfile, value in temp_files:
-                node.set_plug_value(plug_name, value)
-                if os.path.isdir(tmpfile):
-                    try:
-                        shutil.rmtree(tmpfile)
-                    except:
-                        pass
-                else:
-                    try:
-                        os.unlink(tmpfile)
-                    except:
-                        pass
-                # handle additional files (.hdr, .minf...)
-                if os.path.exists(tmpfile + '.minf'):
-                    try:
-                        os.unlink(tmpfile + '.minf')
-                    except:
-                        pass
+            self._free_temporary_files(temp_files)
 
         return returned
 


### PR DESCRIPTION
see https://bioproj.extra.cea.fr/redmine/issues/13749
Nipype processes case is checked and skipped to avoid output files notion confusion. This is a temporary handling until we actually differentiate both output files notions. It should do the work until then.