### PR TITLE
fixes Windows capsul automatic test issues

### DIFF
--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -210,7 +210,8 @@ class Process(Controller):
             "start_time": datetime.isoformat(datetime.utcnow()),
             "cwd": os.getcwd(),
             "returncode": None,
-            "environ": deepcopy(os.environ.data),
+            "environ": dict([(k, unicode(v))
+                             for k, v in os.environ.data.iteritems()]),
             "end_time": None,
             "hostname": getfqdn(),
         }

--- a/capsul/study_config/memory.py
+++ b/capsul/study_config/memory.py
@@ -11,7 +11,6 @@
 
 # System import
 from __future__ import with_statement
-import codecs
 import os
 import hashlib
 import time
@@ -281,7 +280,7 @@ class MemorizedProcess(object):
                 self._copy_files_to_memory(output_parameters, process_dir,
                                            file_mapping)
                 map_fname = os.path.join(process_dir, "file_mapping.json")
-                with codecs.open(map_fname, "w", "utf-8") as open_file:
+                with open(map_fname, "w") as open_file:
                     open_file.write(json.dumps(file_mapping))
 
             except:
@@ -292,7 +291,7 @@ class MemorizedProcess(object):
         else:
             # Restore the memorized files
             map_fname = os.path.join(process_dir, "file_mapping.json")
-            with codecs.open(map_fname, "r", "utf-8") as json_data:
+            with open(map_fname, "r") as json_data:
                 file_mapping = json.load(json_data)
 
             # Go through all mapping files
@@ -378,7 +377,7 @@ class MemorizedProcess(object):
                                check_circular=True, indent=4,
                                cls=CapsulResultEncoder)
         result_fname = os.path.join(process_dir, "result.json")
-        with codecs.open(result_fname, "w", "utf-8") as open_file:
+        with open(result_fname, "w") as open_file:
             open_file.write(json_data)
 
         # Information message
@@ -414,7 +413,7 @@ class MemorizedProcess(object):
             raise KeyError(
                 "Non-existing cache value (may have been cleared).\n"
                 "File {0} does not exist.".format(result_fname))
-        with codecs.open(result_fname, "r", "utf-8") as json_data:
+        with open(result_fname, "r") as json_data:
             result_dict = json.load(json_data, cls=CapsulResultDecoder)
 
         # Generate the ProcessResult

--- a/capsul/study_config/test/test_memory.py
+++ b/capsul/study_config/test/test_memory.py
@@ -121,7 +121,7 @@ class TestMemory(unittest.TestCase):
                                    os.path.basename(__file__))
         self.assertEqual(
             proxy_process.s,
-            "{{'i': '{0}', 'l': ['{0}'], 'f': 2.5}}".format(copied_file))
+            "{{'i': {0}, 'l': [{0}], 'f': 2.5}}".format(repr(copied_file)))
 
 if 0:
     # Configure the environment


### PR DESCRIPTION
This fix is necessary for automatic test to complete on Windows, because:
- some environment variables contains characters that were not correctly encoded when given to json
- some files were not correctly compared

I also removed changes about utf-8 encoding as they were unhelpful.