### PR TITLE
Pipeline edit

### DIFF
--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -1650,7 +1650,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         """ Event to open a sub-process/sub-pipeline controller
         """
         if self._allow_open_controller:
-            self.openPopupMenu(node_name, process)
+            self.open_node_menu(node_name, process)
 
     def openProcessController(self):
         sub_view = QtGui.QScrollArea()
@@ -1671,11 +1671,15 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         # prevent the sub_view to close/delete immediately
         QtCore.QObject.setParent(sub_view, self.window())
 
-    def openPopupMenu(self, node_name, process):
+    def open_node_menu(self, node_name, process):
         """ right-click popup menu for nodes
         """
-        menu = QtGui.QMenu('Nodes handling', None)
         node_name = unicode(node_name) # in case it is a QString
+        menu = QtGui.QMenu('Node: %s' % node_name, None)
+        title = menu.addAction('Node: %s' % node_name)
+        title.setEnabled(False)
+        menu.addSeparator()
+
         self.current_node_name = node_name
         self.current_process = process
         if node_name in ('inputs', 'outputs'):
@@ -1756,7 +1760,11 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         '''
         self.click_pos = QtGui.QCursor.pos()
         has_dot = distutils.spawn.find_executable('dot')
-        menu = QtGui.QMenu('background menu', None)
+        menu = QtGui.QMenu('Pipeline level menu', None)
+        title = menu.addAction('Pipeline level menu')
+        title.setEnabled(False)
+        menu.addSeparator()
+
         if self.is_logical_view():
             logical_view = menu.addAction('Switch to regular parameters view')
         else:

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -814,8 +814,8 @@ class PipelineScene(QtGui.QGraphicsScene):
         if self.logical_view:
             source_param = 'outputs'
             dest_param = 'inputs'
-        source_dest = ((source_gnode_name, source_param),
-            (dest_gnode_name, dest_param))
+        source_dest = ((str(source_gnode_name), str(source_param)),
+            (str(dest_gnode_name), str(dest_param)))
         if source_dest in self.glinks:
             # already done
             if self.logical_view:
@@ -855,8 +855,8 @@ class PipelineScene(QtGui.QGraphicsScene):
             source_param = 'outputs'
             dest_param = 'inputs'
         dest_gnode = self.gnodes.get(dest_gnode_name)
-        new_source_dest = ((source_gnode_name, source_param),
-                           (dest_gnode_name, dest_param))
+        new_source_dest = ((str(source_gnode_name), str(source_param)),
+                           (str(dest_gnode_name), str(dest_param)))
         glink = self.glinks.get(new_source_dest)
         if glink is not None:
             self.removeItem(glink)
@@ -1006,9 +1006,16 @@ class PipelineScene(QtGui.QGraphicsScene):
                 source_node_name = ''
             if dest_node_name == 'outputs':
                 dest_node_name = ''
-            source_plug \
-                = pipeline.nodes[source_node_name].plugs.get(source_param)
-            dest_plug = pipeline.nodes[dest_node_name].plugs.get(dest_param)
+            source_node = pipeline.nodes.get(source_node_name)
+            if source_node is None:
+                to_remove.append(source_dest)
+                continue
+            source_plug = source_node.plugs.get(source_param)
+            dest_node = pipeline.nodes.get(dest_node_name)
+            if dest_node is None:
+                to_remove.append(dest_node_name)
+                continue
+            dest_plug = dest_node.plugs.get(dest_param)
             remove_glink = False
             if source_plug is None or dest_plug is None:
                 # plug[s] removed
@@ -2320,7 +2327,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         self.scene.update_pipeline()
 
     def _del_link(self):
-        #src_node, src_plug, dst_node, dst_plug = self._current_link
+        # src_node, src_plug, dst_node, dst_plug = self._current_link
         link_def = self._current_link
         self.scene.pipeline.remove_link(link_def)
         self.scene.update_pipeline()

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -1799,8 +1799,33 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
                     action.setChecked(True)
 
         if node is not self.scene.pipeline.pipeline_node:
+            menu.addSeparator()
             del_node_action = menu.addAction('Delete node')
             del_node_action.triggered.connect(self.del_node)
+            export_mandatory_plugs = menu.addAction(
+                'Export unconnected mandatory plugs')
+            export_mandatory_plugs.triggered.connect(
+                self.export_node_unconnected_mandatory_plugs)
+            export_all_plugs = menu.addAction(
+                'Export all unconnected plugs')
+            export_all_plugs.triggered.connect(
+                self.export_node_all_unconnected_plugs)
+            export_mandatory_inputs = menu.addAction(
+                'Export unconnected mandatory inputs')
+            export_mandatory_inputs.triggered.connect(
+                self.export_node_unconnected_mandatory_inputs)
+            export_all_inputs = menu.addAction(
+                'Export all unconnected inputs')
+            export_all_inputs.triggered.connect(
+                self.export_node_all_unconnected_inputs)
+            export_mandatory_outputs = menu.addAction(
+                'Export unconnected mandatory outputs')
+            export_mandatory_outputs.triggered.connect(
+                self.export_node_unconnected_mandatory_outputs)
+            export_all_outputs = menu.addAction(
+                'Export all unconnected outputs')
+            export_all_outputs.triggered.connect(
+                self.export_node_all_unconnected_outputs)
 
         menu.exec_(QtGui.QCursor.pos())
         del self.current_node_name
@@ -1852,6 +1877,32 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         add_proc.triggered.connect(self.add_process)
         add_switch = menu.addAction('Add switch in pipeline')
         add_switch.triggered.connect(self.add_switch)
+
+        menu.addSeparator()
+        export_mandatory_plugs = menu.addAction(
+            'Export unconnected mandatory plugs')
+        export_mandatory_plugs.triggered.connect(
+            self.export_unconnected_mandatory_plugs)
+        export_all_plugs = menu.addAction(
+            'Export all unconnected plugs')
+        export_all_plugs.triggered.connect(
+            self.export_all_unconnected_plugs)
+        export_mandatory_inputs = menu.addAction(
+            'Export unconnected mandatory inputs')
+        export_mandatory_inputs.triggered.connect(
+            self.export_unconnected_mandatory_inputs)
+        export_all_inputs = menu.addAction(
+            'Export all unconnected inputs')
+        export_all_inputs.triggered.connect(
+            self.export_all_unconnected_inputs)
+        export_mandatory_outputs = menu.addAction(
+            'Export unconnected mandatory outputs')
+        export_mandatory_outputs.triggered.connect(
+            self.export_unconnected_mandatory_outputs)
+        export_all_outputs = menu.addAction(
+            'Export all unconnected outputs')
+        export_all_outputs.triggered.connect(
+            self.export_all_unconnected_outputs)
 
         menu.exec_(QtGui.QCursor.pos())
         del self.click_pos
@@ -2061,6 +2112,65 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
             pipeline.nodes_activation.remove_trait(node_name)
         self.scene.remove_node(node_name)
         self.scene.pipeline.update_nodes_and_plugs_activation()
+
+    def export_node_plugs(self, node_name, inputs=True, outputs=True,
+                          optional=False):
+        pipeline = self.scene.pipeline
+        node = pipeline.nodes[node_name]
+        for parameter_name, plug in node.plugs.iteritems():
+            if parameter_name in ("nodes_activation", "selection_changed"):
+                continue
+            if (((node_name, parameter_name) not in pipeline.do_not_export and
+                ((outputs and plug.output and not plug.links_to) or
+                    (inputs and not plug.output and not plug.links_from)) and
+                (optional or not node.get_trait(parameter_name).optional))):
+                pipeline.export_parameter(node_name, parameter_name)
+
+    def export_plugs(self, inputs=True, outputs=True, optional=False):
+        for node_name in self.scene.pipeline.nodes:
+            if node_name != "":
+                self.export_node_plugs(node_name, inputs=inputs,
+                                       outputs=outputs, optional=optional)
+
+    def export_node_unconnected_mandatory_plugs(self):
+        self.export_node_plugs(self.current_node_name)
+
+    def export_node_all_unconnected_plugs(self):
+        self.export_node_plugs(self.current_node_name, optional=True)
+
+    def export_node_unconnected_mandatory_inputs(self):
+        self.export_node_plugs(
+            self.current_node_name, inputs=True, outputs=False)
+
+    def export_node_all_unconnected_inputs(self):
+        self.export_node_plugs(
+            self.current_node_name, inputs=True, outputs=False, optional=True)
+
+    def export_node_unconnected_mandatory_outputs(self):
+        self.export_node_plugs(
+            self.current_node_name, inputs=False, outputs=True)
+
+    def export_node_all_unconnected_outputs(self):
+        self.export_node_plugs(
+            self.current_node_name, inputs=False, outputs=True, optional=True)
+
+    def export_unconnected_mandatory_plugs(self):
+        self.export_plugs()
+
+    def export_all_unconnected_plugs(self):
+        self.export_plugs(optional=True)
+
+    def export_unconnected_mandatory_inputs(self):
+        self.export_plugs(inputs=True, outputs=False)
+
+    def export_all_unconnected_inputs(self):
+        self.export_plugs(inputs=True, outputs=False, optional=True)
+
+    def export_unconnected_mandatory_outputs(self):
+        self.export_plugs(inputs=False, outputs=True)
+
+    def export_all_unconnected_outputs(self):
+        self.export_plugs(inputs=False, outputs=True, optional=True)
 
     def add_process(self):
         '''

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2302,7 +2302,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
                 break
         weak_action = menu.addAction('Weak link')
         weak_action.setCheckable(True)
-        weak_action.setChecked(weak)
+        weak_action.setChecked(bool(weak))
         weak_action.toggled.connect(self._change_weak_link)
 
         menu.addSeparator()

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2195,7 +2195,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
             node = pipeline.nodes[node_name]
             gnode = self.scene.add_node(node_name, node)
             gnode.setPos(self.mapToScene(self.mapFromGlobal(self.click_pos)))
-            self.scene.pipeline.update_pipeline()
+            self.scene.update_pipeline()
 
     def _plug_clicked(self, name):
         if self.is_logical_view():

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2138,15 +2138,51 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
             pipeline.add_process(node_name, process)
 
             node = pipeline.nodes[node_name]
-            if isinstance(node, PipelineNode):
-                sub_pipeline = node.process
-            else:
-                sub_pipeline = None
             gnode = self.scene.add_node(node_name, node)
             gnode.setPos(self.mapToScene(self.mapFromGlobal(self.click_pos)))
 
     def add_switch(self):
-        pass
+        '''
+        Insert a switch node in the pipeline. Asks for the switch
+        inputs/outputs, and the node name before inserting.
+        '''
+
+        class SwitchInput(QtGui.QDialog):
+            def __init__(self):
+                super(SwitchInput, self).__init__()
+                self.setWindowTitle('switch parameters/name:')
+                layout = QtGui.QGridLayout(self)
+                layout.addWidget(QtGui.QLabel('inputs:'), 0, 0)
+                self.inputs_line = QtGui.QLineEdit()
+                layout.addWidget(self.inputs_line, 0, 1)
+                layout.addWidget(QtGui.QLabel('outputs:'), 1, 0)
+                self.outputs_line = QtGui.QLineEdit()
+                layout.addWidget(self.outputs_line, 1, 1)
+                layout.addWidget(QtGui.QLabel('node name'), 2, 0)
+                self.name_line = QtGui.QLineEdit()
+                layout.addWidget(self.name_line, 2, 1)
+                ok = QtGui.QPushButton('OK')
+                layout.addWidget(ok, 3, 0)
+                cancel = QtGui.QPushButton('Cancel')
+                layout.addWidget(cancel, 3, 1)
+                ok.clicked.connect(self.accept)
+                cancel.clicked.connect(self.reject)
+
+        switch_name_gui = SwitchInput()
+        switch_name_gui.resize(600, switch_name_gui.sizeHint().height())
+
+        res = switch_name_gui.exec_()
+        if res:
+            pipeline = self.scene.pipeline
+            node_name = str(switch_name_gui.name_line.text())
+            inputs = str(switch_name_gui.inputs_line.text()).split()
+            outputs = str(switch_name_gui.outputs_line.text()).split()
+            pipeline.add_switch(node_name, inputs, outputs)
+
+            node = pipeline.nodes[node_name]
+            gnode = self.scene.add_node(node_name, node)
+            gnode.setPos(self.mapToScene(self.mapFromGlobal(self.click_pos)))
+            self.pipeline.update_pipeline()
 
     def _plug_clicked(self, name):
         if self.is_logical_view():

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -946,14 +946,14 @@ class PipelineScene(QtGui.QGraphicsScene):
                     else:
                         pipeline_inputs[name] = plug
                 if pipeline_inputs and 'inputs' not in self.gnodes:
-                    self.add_node(
+                    self._add_node(
                         'inputs', NodeGWidget(
                             'inputs', pipeline_inputs, pipeline,
                             process=pipeline,
                             colored_parameters=self.colored_parameters,
                             logical_view=self.logical_view))
                 if pipeline_outputs and 'outputs' not in self.gnodes:
-                    self.add_node(
+                    self._add_node(
                         'outputs', NodeGWidget(
                             'outputs', pipeline_outputs, pipeline,
                             process=pipeline,
@@ -969,11 +969,7 @@ class PipelineScene(QtGui.QGraphicsScene):
                     sub_pipeline = node.process
                 else:
                     sub_pipeline = None
-                self.add_node(node_name, NodeGWidget(
-                    node_name, node.plugs, pipeline,
-                    sub_pipeline=sub_pipeline, process=process,
-                    colored_parameters=self.colored_parameters,
-                    logical_view=self.logical_view))
+                self.add_node(node_name, node)
 
         # links
         to_remove = []
@@ -1056,14 +1052,14 @@ class PipelineScene(QtGui.QGraphicsScene):
                     else:
                         pipeline_inputs['inputs'] = plug
                 if pipeline_inputs and 'inputs' not in self.gnodes:
-                    self.add_node(
+                    self._add_node(
                         'inputs', NodeGWidget(
                             'inputs', pipeline_inputs, pipeline,
                             process=pipeline,
                             colored_parameters=self.colored_parameters,
                             logical_view=self.logical_view))
                 if pipeline_outputs and 'outputs' not in self.gnodes:
-                    self.add_node(
+                    self._add_node(
                         'outputs', NodeGWidget(
                             'outputs', pipeline_outputs, pipeline,
                             process=pipeline,
@@ -1079,11 +1075,7 @@ class PipelineScene(QtGui.QGraphicsScene):
                     sub_pipeline = node.process
                 else:
                     sub_pipeline = None
-                self.add_node(node_name, NodeGWidget(
-                    node_name, node.plugs, pipeline,
-                    sub_pipeline=sub_pipeline, process=process,
-                    colored_parameters=self.colored_parameters,
-                    logical_view=self.logical_view))
+                self.add_node(node_name, node)
 
         # links
         # delete all links

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2122,6 +2122,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
                 model.setStringList(list(compl))
 
         proc_name_gui = ProcessModuleInput()
+        proc_name_gui.resize(800, proc_name_gui.sizeHint().height())
 
         res = proc_name_gui.exec_()
         if res:

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2191,11 +2191,9 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
             inputs = str(switch_name_gui.inputs_line.text()).split()
             outputs = str(switch_name_gui.outputs_line.text()).split()
             pipeline.add_switch(node_name, inputs, outputs)
-
-            node = pipeline.nodes[node_name]
-            gnode = self.scene.add_node(node_name, node)
+            # add_switch triggers an update
+            gnode = self.scene.gnodes[node_name]
             gnode.setPos(self.mapToScene(self.mapFromGlobal(self.click_pos)))
-            self.scene.update_pipeline()
 
     def _plug_clicked(self, name):
         if self.is_logical_view():

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2560,6 +2560,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         Ask for a filename using the file dialog, and save the pipeline as a XML
         file.
         '''
+        pipeline = self.scene.pipeline
         old_filename = getattr(self, '_pipeline_filename', '')
         filename = QtGui.QFileDialog.getSaveFileName(
             None, 'Save the pipeline', os.path.dirname(old_filename),
@@ -2567,12 +2568,11 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         if filename:
             posdict = dict([(key, (value.x(), value.y())) \
                             for key, value in self.scene.pos.iteritems()])
-            old_pos = p.node_position
-            p.node_position = posdict
-            xml_to_pipeline.pipeline_to_xml(self.scene.pipeline,
-                                            open(filename, 'w'))
+            old_pos = pipeline.node_position
+            pipeline.node_position = posdict
+            xml_to_pipeline.pipeline_to_xml(pipeline, open(filename, 'w'))
             self._pipeline_filename = unicode(filename)
-            p.node_position = old_pos
+            pipeline.node_position = old_pos
 
 
 

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2182,7 +2182,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
             node = pipeline.nodes[node_name]
             gnode = self.scene.add_node(node_name, node)
             gnode.setPos(self.mapToScene(self.mapFromGlobal(self.click_pos)))
-            self.pipeline.update_pipeline()
+            self.scene.pipeline.update_pipeline()
 
     def _plug_clicked(self, name):
         if self.is_logical_view():

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -30,6 +30,7 @@ from capsul.qt_gui.widgets.pipeline_file_warning_widget \
 from capsul.utils.loader import load_objects
 from soma.controller import Controller
 from soma.utils.functiontools import SomaPartial
+from capsul.utils import xml_to_pipeline
 try:
     from traits import api as traits
 except ImportError:
@@ -1904,6 +1905,10 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         export_all_outputs.triggered.connect(
             self.export_all_unconnected_outputs)
 
+        menu.addSeparator()
+        save = menu.addAction('Save pipeline')
+        save.triggered.connect(self.save_pipeline)
+
         menu.exec_(QtGui.QCursor.pos())
         del self.click_pos
 
@@ -2549,6 +2554,25 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
 
     def _prune_plugs(self):
         print 'TODO.'
+
+    def save_pipeline(self):
+        '''
+        Ask for a filename using the file dialog, and save the pipeline as a XML
+        file.
+        '''
+        old_filename = getattr(self, '_pipeline_filename', '')
+        filename = QtGui.QFileDialog.getSaveFileName(
+            None, 'Save the pipeline', os.path.dirname(old_filename),
+            'XML files (*.xml);; All (*)', old_filename)
+        if filename:
+            posdict = dict([(key, (value.x(), value.y())) \
+                            for key, value in self.scene.pos.iteritems()])
+            old_pos = p.node_position
+            p.node_position = posdict
+            xml_to_pipeline.pipeline_to_xml(self.scene.pipeline,
+                                            open(filename, 'w'))
+            self._pipeline_filename = unicode(filename)
+            p.node_position = old_pos
 
 
 

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -28,6 +28,7 @@ from capsul.api import Process
 from capsul.process.loader import get_process_instance
 from capsul.qt_gui.widgets.pipeline_file_warning_widget \
     import PipelineFileWarningWidget
+import capsul.pipeline.xml as capsulxml
 from capsul.process import loader
 from soma.controller import Controller
 from soma.utils.functiontools import SomaPartial
@@ -2617,7 +2618,7 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
             old_pos = pipeline.node_position
             pipeline.node_position = posdict
             # FIXME: save implementation has gone...
-            xml_to_pipeline.pipeline_to_xml(pipeline, open(filename, 'w'))
+            capsulxml.save_xml_pipeline(pipeline, filename)
             self._pipeline_filename = unicode(filename)
             pipeline.node_position = old_pos
 

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -2017,8 +2017,6 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
         cancel.clicked.connect(proc_name_gui.reject)
 
         res = proc_name_gui.exec_()
-        del ok, cancel, name_line, proc_line
-        del layout
         if res:
             proc_module = unicode(proc_line.text())
             node_name = str(name_line.text())
@@ -2037,6 +2035,8 @@ class PipelineDevelopperView(QtGui.QGraphicsView):
                 sub_pipeline = None
             gnode = self.scene.add_node(node_name, node)
             gnode.setPos(self.mapToScene(self.mapFromGlobal(self.click_pos)))
+        del ok, cancel, name_line, proc_line
+        del layout
 
     def add_switch(self):
         pass


### PR DESCRIPTION
Pipeline edition features in PIpelineDevelopperView.
They are optionally enabled or disabled via the enable_edition option of the constructor, or the set_enable_edition() method.
Allows to add/delete processes / switches, export plugs, save the pipeline... (the GUI is not perfect but it allows to perform some edition and save the work)
