### PR TITLE
Make Process.run() use StudyCongig.run() to avoid having two different ways to execute pipelines

### DIFF
--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -1324,37 +1324,12 @@ class Pipeline(Process):
                     pass
 
     def _run_process(self):
-        """ Execution of the pipeline.
-
-        Since  no study configuration are set, execute the pipeline in a
-        sequential order, single-processor mode.
-
-        Returns
-        -------
-        returned: list
-            the execution return results of each node in the worflow
-        """
-        # Get all the process nodes to execute
-        nodes_list = self.workflow_ordered_nodes()
-        temp_files = []
-
-        try:
-            # Go through all process nodes
-            returned = []
-            for node in nodes_list:
-
-                # check temporary outputs and allocate files
-                self._check_temporary_files_for_node(node, temp_files)
-
-                # Execute the process contained in the node
-                node_ret = node.process()
-                returned.append(node_ret)
-
-        finally:
-            # delete and reset temp files
-            self._free_temporary_files(temp_files)
-
-        return returned
+        '''
+        Pipeline execution is managed by StudyConfig class.
+        This method must not be called.
+        '''
+        raise NotImplementedError('Pipeline execution is managed by '
+            'StudyConfig class. This method must not be called.')
 
     def find_empty_parameters(self):
         """ Find internal File/Directory parameters not exported to the main

--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -761,10 +761,13 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
         return getattr(self, name)
 
     def run(self, *args, **kwargs):
-        from capsul.study_config import StudyConfig
+        """Shortcut to default_study_config().run()"""
+        # Import cannot be done on module due to circular dependencies
+        from capsul.study_config import default_study_config
         output_directory = getattr(self, 'output_directory', Undefined)
-        study_config = StudyConfig(output_directory=output_directory)
-        return study_config.run(self, *args, **kwargs)
+        return default_study_config().run(self, *args, 
+                                          output_directory=output_directory,
+                                          **kwargs)
 
 
 class FileCopyProcess(Process):

--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -242,7 +242,7 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
                 self.set_parameter(arg_name, arg_val)
 
         # Execute the process
-        returncode = self._run_process()
+        returncode = self.run()
 
         # Set the execution stop time in the execution report
         runtime["end_time"] = datetime.isoformat(datetime.utcnow())
@@ -762,8 +762,9 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
 
     def run(self, *args, **kwargs):
         from capsul.study_config import StudyConfig
-        study_config = StudyConfig()
-        return study_config.run(self, *args, **kwargs)[0]
+        output_directory = getattr(self, 'output_directory', Undefined)
+        study_config = StudyConfig(output_directory=output_directory)
+        return study_config.run(self, *args, **kwargs)
 
 
 class FileCopyProcess(Process):

--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -30,7 +30,6 @@ from traits.trait_handlers import BaseTraitHandler
 # Soma import
 from soma.controller import Controller
 from soma.controller import trait_ids
-from soma.utils import LateBindingProperty
 from soma.controller.trait_utils import is_trait_value_defined
 from soma.controller.trait_utils import is_trait_pathname
 from soma.controller.trait_utils import get_trait_desc
@@ -761,9 +760,10 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
         """
         return getattr(self, name)
 
-    run = LateBindingProperty(
-        _run_process, None, None,
-        "Processing method that has to be defined in derived classes")
+    def run(self, *args, **kwargs):
+        from capsul.study_config import StudyConfig
+        study_config = StudyConfig()
+        return study_config.run(self, *args, **kwargs)[0]
 
 
 class FileCopyProcess(Process):
@@ -1174,8 +1174,6 @@ class NipypeProcess(FileCopyProcess):
         from .nipype_process import nipype_factory
         cls_instance = nipype_factory(nipype_interface)
         return cls_instance.get_help(returnhelp)
-
-    run = property(_run_process)
 
 
 class ProcessResult(object):

--- a/capsul/study_config/__init__.py
+++ b/capsul/study_config/__init__.py
@@ -6,4 +6,4 @@
 # for details.
 ##########################################################################
 
-from .study_config import StudyConfig
+from study_config import StudyConfig, default_study_config

--- a/capsul/study_config/run.py
+++ b/capsul/study_config/run.py
@@ -79,7 +79,9 @@ def run_process(output_dir, process_instance, cachedir=None,
         # Execute the proxy process
         returncode = proxy_instance(**kwargs)
     else:
-        returncode = process_instance._run_process(**kwargs)
+        for k, v in kwargs.iteritems():
+            setattr(process_instance, k, v)
+        returncode = process_instance._run_process()
 
     # Save the process log
     if generate_logging:

--- a/capsul/study_config/run.py
+++ b/capsul/study_config/run.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def run_process(output_dir, process_instance, cachedir=None,
-                generate_logging=False, verbose=1, **kwargs):
+                generate_logging=False, verbose=0, **kwargs):
     """ Execute a capsul process in a specific directory.
 
     Parameters
@@ -45,13 +45,13 @@ def run_process(output_dir, process_instance, cachedir=None,
     output_log_file: str
         the path to the process execution log file.
     """
-    # Guarantee that the output directory exists
-    if not os.path.isdir(output_dir):
-        os.makedirs(output_dir)
-
     # Update the output directory folder if necessary
     if output_dir is Undefined:
         output_dir = os.getcwd()
+
+    # Guarantee that the output directory exists
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)
 
     # Set the current directory directory if necessary
     if hasattr(process_instance, "_nipype_interface"):
@@ -71,12 +71,15 @@ def run_process(output_dir, process_instance, cachedir=None,
             os.path.dirname(output_dir) + ".json")
         process_instance.log_file = output_log_file
 
-    # Create a memory object
-    mem = Memory(cachedir)
-    proxy_instance = mem.cache(process_instance, verbose=verbose)
+    if cachedir:
+        # Create a memory object
+        mem = Memory(cachedir)
+        proxy_instance = mem.cache(process_instance, verbose=verbose)
 
-    # Execute the proxy process
-    returncode = proxy_instance(**kwargs)
+        # Execute the proxy process
+        returncode = proxy_instance(**kwargs)
+    else:
+        returncode = process_instance._run_process(**kwargs)
 
     # Save the process log
     if generate_logging:

--- a/capsul/study_config/study_config.py
+++ b/capsul/study_config/study_config.py
@@ -332,14 +332,15 @@ class StudyConfig(Controller):
                 for process_node in execution_list:
                     # Execute the process instance contained in the node
                     if isinstance(process_node, Node):
-                        self._run(process_node.process, verbose, **kwargs)
+                        result = self._run(process_node.process, verbose, **kwargs)
 
                     # Execute the process instance
                     else:
-                        self._run(process_node, verbose, **kwargs)
+                        result = self._run(process_node, verbose, **kwargs)
             finally:
                 if temporary_files:
                     process_or_pipeline._free_temporary_files(temporary_files)
+            return result
 
     def _run(self, process_instance, verbose, **kwargs):
         """ Method to execute a process in a study configuration environment.
@@ -356,18 +357,12 @@ class StudyConfig(Controller):
             process_instance.id))
 
         # Run
-        if self.output_directory is Undefined:
-            destination_folder = Undefined
-        else:
-            destination_folder = os.path.join(
-                self.output_directory,
-                "{0}-{1}".format(self.process_counter, process_instance.name))
         if self.get_trait_value("use_smart_caching") in [None, False]:
             cachedir = None
         else:
             cachedir = self.output_directory
         returncode, log_file = run_process(
-            destination_folder,
+            self.output_directory,
             process_instance,
             cachedir,
             self.generate_logging,

--- a/capsul/study_config/study_config.py
+++ b/capsul/study_config/study_config.py
@@ -239,8 +239,8 @@ class StudyConfig(Controller):
             self.modules[config_module_name] = module
             return module
 
-    def run(self, process_or_pipeline, executer_qc_nodes=True, verbose=1,
-            **kwargs):
+    def run(self, process_or_pipeline, output_directory= None,
+            executer_qc_nodes=True, verbose=1, **kwargs):
         """ Method to execute a process or a pipline in a study configuration
          environment.
 
@@ -254,6 +254,9 @@ class StudyConfig(Controller):
         ----------
         process_or_pipeline: Process or Pipeline instance (mandatory)
             the process or pipeline we want to execute
+        output_directory: Directory name (optional)
+            the output directory to use for process execution. This replaces
+            self.output_directory but left it unchanged.
         execute_qc_nodes: bool (optional, default False)
             if True execute process nodes that are taged as qualtity control
             process nodes.
@@ -290,36 +293,41 @@ class StudyConfig(Controller):
 
         # Use the local machine to execute the pipeline or process
         else:
+            if output_directory is None:
+                output_directory = self.output_directory
             # Not all processes need an output_directory defined on
-            # studt_config
-            if self.output_directory is not Undefined:
+            # StudyConfig
+            if output_directory is not Undefined:
                 # Check the output directory is valid
-                if not isinstance(self.output_directory, basestring):
+                if not isinstance(output_directory, basestring):
                     raise ValueError(
                         "'{0}' is not a valid directory. A valid output "
                         "directory is expected to run the process or "
-                        "pipeline.".format(self.output_directory))
+                        "pipeline.".format(output_directory))
                 try:
-                    if not os.path.isdir(self.output_directory):
-                        os.makedirs(self.output_directory)
+                    if not os.path.isdir(output_directory):
+                        os.makedirs(output_directory)
                 except:
                     raise ValueError(
                         "Can't create folder '{0}', please investigate.".format(
-                            self.output_directory))
+                            output_directory))
 
-            # Generate ordered execution list
+            # Temporary files can be generated for pipelines
             temporary_files = []
             try:
+                # Generate ordered execution list
                 execution_list = []
                 if isinstance(process_or_pipeline, Pipeline):
-                    execution_list = process_or_pipeline.workflow_ordered_nodes()
+                    execution_list = \
+                        process_or_pipeline.workflow_ordered_nodes()
                     # Filter process nodes if necessary
                     if not executer_qc_nodes:
                         execution_list = [node for node in execution_list
                                         if node.node_type != "view_node"]
                     for node in execution_list:
                         # check temporary outputs and allocate files
-                        process_or_pipeline._check_temporary_files_for_node(node, temporary_files)
+                        process_or_pipeline._check_temporary_files_for_node(
+                            node, temporary_files)
                 elif isinstance(process_or_pipeline, Process):
                     execution_list.append(process_or_pipeline)
                 else:
@@ -332,23 +340,33 @@ class StudyConfig(Controller):
                 for process_node in execution_list:
                     # Execute the process instance contained in the node
                     if isinstance(process_node, Node):
-                        result = self._run(process_node.process, verbose, **kwargs)
+                        result = self._run(process_node.process, 
+                                           output_directory, 
+                                           verbose, **kwargs)
 
                     # Execute the process instance
                     else:
-                        result = self._run(process_node, verbose, **kwargs)
+                        result = self._run(process_node, output_directory,
+                                           verbose, **kwargs)
             finally:
+                # Destroy temporary files
                 if temporary_files:
+                    # If temporary files have been created, we are sure that
+                    # process_or_pipeline is a pipeline with a method
+                    # _free_temporary_files.
                     process_or_pipeline._free_temporary_files(temporary_files)
             return result
 
-    def _run(self, process_instance, verbose, **kwargs):
+    def _run(self, process_instance, output_directory, verbose, **kwargs):
         """ Method to execute a process in a study configuration environment.
 
         Parameters
         ----------
         process_instance: Process instance (mandatory)
             the process we want to execute
+        output_directory: Directory name (optional)
+            the output directory to use for process execution. This replaces
+            self.output_directory but left it unchanged.
         verbose: int
             if different from zero, print console messages.
         """
@@ -360,9 +378,9 @@ class StudyConfig(Controller):
         if self.get_trait_value("use_smart_caching") in [None, False]:
             cachedir = None
         else:
-            cachedir = self.output_directory
+            cachedir = output_directory
         returncode, log_file = run_process(
-            self.output_directory,
+            output_directory,
             process_instance,
             cachedir,
             self.generate_logging,
@@ -594,6 +612,19 @@ class StudyConfig(Controller):
         else:
             return None
 
+_default_study_config = None
+def default_study_config():
+    """
+    On the first call create a StudyConfig instance with defaut configuration
+    (eventualy reading configuration files). Then returns this instance on all
+    subsequent calls.
+    """
+    global _default_study_config
+    if _default_study_config is None:
+        _default_study_config = StudyConfig()
+    return _default_study_config
+
+    
 
 class StudyConfigModule(object):
     @property

--- a/capsul/study_config/test/test_run_in_study_config.py
+++ b/capsul/study_config/test/test_run_in_study_config.py
@@ -81,8 +81,7 @@ class TestRunProcess(unittest.TestCase):
             self.assertEqual(process.res, param[0] * param[1])
             self.assertEqual(
                 process.output_directory,
-                os.path.join(self.output_directory, "{0}-{1}".format(
-                    self.study_config.process_counter - 1, process.name)))
+                self.output_directory)
 
 
 def test():

--- a/capsul/study_config/test/test_run_process.py
+++ b/capsul/study_config/test/test_run_process.py
@@ -40,26 +40,28 @@ class TestRunProcess(unittest.TestCase):
         """
         # Create a study configuration
         self.output_dir = tempfile.mkdtemp()
-        self.cachedir = self.output_dir
+        try:
+            self.cachedir = self.output_dir
 
-        # Call the test
-        self.execution_dummy()
-
-        # Rm temporary folder
-        shutil.rmtree(self.output_dir)
+            # Call the test
+            self.execution_dummy()
+        finally:
+            # Rm temporary folder
+            shutil.rmtree(self.output_dir)
 
     def test_execution_without_cache(self):
         """ Execute a process without cache.
         """
         # Create a study configuration
         self.output_dir = tempfile.mkdtemp()
-        self.cachedir = None
+        try:
+            self.cachedir = None
 
-        # Call the test
-        self.execution_dummy()
-
-        # Rm temporary folder
-        shutil.rmtree(self.output_dir)
+            # Call the test
+            self.execution_dummy()
+        finally:
+            # Rm temporary folder
+            shutil.rmtree(self.output_dir)
 
     def execution_dummy(self):
         """ Test to execute DummyProcess.


### PR DESCRIPTION
Processes.run was a property that automatically executed _run_process. This was weird not to have a method for that. Moreover, there was two codes for executing pipelines locally (i.e. without soma-workflow), one in StudyConfig and the other one in Pipeline._run_process. I merged the two in StudyConfig and make Process.run() create a default StudyConfig to execute the process.
