### PR TITLE
Fixed XML output management and add corresponding tests

### DIFF
--- a/capsul/process/test/test_load_from_description.py
+++ b/capsul/process/test/test_load_from_description.py
@@ -145,7 +145,7 @@ def divide_list(a, b):
 ''')
 def divides_dict(a, b):
      return {
-        'quotients': [i / j for i, j in zip(a, b)],
+        'quotients': [int(i / j) for i, j in zip(a, b)],
         'remainders': [i % j for i, j in zip(a, b)],
     }
  
@@ -160,7 +160,7 @@ def divides_dict(a, b):
 </process>
 ''')
 def divides_list(a, b):
-     return [[i / j for i, j in zip(a, b)],
+     return [[int(i / j) for i, j in zip(a, b)],
              [i % j for i, j in zip(a, b)]]
  
  
@@ -175,7 +175,7 @@ def divides_list(a, b):
 ''')
 def divides_single_dict(a, b):
      return {
-        'quotients': [i / j for i, j in zip(a, b)],
+        'quotients': [int(i / j) for i, j in zip(a, b)],
     }
 
 @xml_process('''
@@ -188,7 +188,7 @@ def divides_single_dict(a, b):
 </process>
 ''')
 def divides_single_list(a, b):
-     return [[i / j for i, j in zip(a, b)]]
+     return [[int(i / j) for i, j in zip(a, b)]]
 
 
 class TestLoadFromDescription(unittest.TestCase):
@@ -286,7 +286,7 @@ class TestLoadFromDescription(unittest.TestCase):
         
         a = range(40, 50)
         b = range(10, 21)
-        quotients = [i / j for i, j in zip(range(40, 50), range(10, 21))]
+        quotients = [int(i / j) for i, j in zip(range(40, 50), range(10, 21))]
         remainders = [i % j for i, j in zip(range(40, 50), range(10, 21))]
         
         process = get_process_instance(

--- a/capsul/process/test/test_load_from_description.py
+++ b/capsul/process/test/test_load_from_description.py
@@ -116,7 +116,7 @@ def join(value1, value2, value3):
 ''')
 def divide_dict(a, b):
      return {
-        'quotient': a / b,
+        'quotient': int(a / b),
         'remainder': a % b,
     }
 
@@ -131,7 +131,7 @@ def divide_dict(a, b):
 </process>
 ''')
 def divide_list(a, b):
-     return [a / b, a % b]
+     return [int(a / b), a % b]
 
 @xml_process('''
 <process capsul_xml="2.0">

--- a/capsul/process/test/test_load_from_description.py
+++ b/capsul/process/test/test_load_from_description.py
@@ -284,8 +284,8 @@ class TestLoadFromDescription(unittest.TestCase):
         self.assertEqual(process.quotient, 14)
         self.assertEqual(process.remainder, 0)
         
-        a = range(40, 50)
-        b = range(10, 21)
+        a = list(range(40, 50))
+        b = list(range(10, 21))
         quotients = [int(i / j) for i, j in zip(range(40, 50), range(10, 21))]
         remainders = [i % j for i, j in zip(range(40, 50), range(10, 21))]
         

--- a/capsul/process/xml.py
+++ b/capsul/process/xml.py
@@ -64,11 +64,8 @@ class XMLProcess(Process):
                                      'returned by process %s' % 
                                      (len(result), len(self._function_outputs),
                                       self.id))
-                if len(self._function_outputs) == 1:
-                    setattr(self, self._function_outputs[0], result)
-                else:
-                    for i in xrange(len(self._function_outputs)):
-                        setattr(self, self._function_outputs[i], result[i])
+                for i in xrange(len(self._function_outputs)):
+                    setattr(self, self._function_outputs[i], result[i])
             elif isinstance(result, dict):
                 # Return value is a dict, set the output parameter values.
                 for i in self._function_outputs:


### PR DESCRIPTION
This pull request is reverting a change introduced in #82 regarding the way output of XML processes are handled. I think this change was introduced due to misunderstanding of the XML 2.0 specification. The specification is badly written for this part (my fault, sorry, I will fix that), however examples are correct. An XML process must always use the `<return>` tag to define its output(s). If there is only one result, `<return>` tag contains the name, type and doc attributes of the returned value. If there are more than one output, the `<return>`tag has no attributes and only contains `<output>` tags that describe the parameters.

